### PR TITLE
Fix nodemailer method name from createTransporter to createTransport

### DIFF
--- a/backend/services/emailService.js
+++ b/backend/services/emailService.js
@@ -10,7 +10,7 @@ class EmailService {
     // Create transporter based on environment
     if (process.env.NODE_ENV === 'production') {
       // Production: Use SMTP service (Gmail, SendGrid, etc.)
-      this.transporter = nodemailer.createTransporter({
+      this.transporter = nodemailer.createTransport({
         service: process.env.EMAIL_SERVICE || 'gmail',
         auth: {
           user: process.env.EMAIL_USER,
@@ -26,7 +26,7 @@ class EmailService {
   async createTestAccount() {
     try {
       const testAccount = await nodemailer.createTestAccount()
-      this.transporter = nodemailer.createTransporter({
+      this.transporter = nodemailer.createTransport({
         host: 'smtp.ethereal.email',
         port: 587,
         secure: false,


### PR DESCRIPTION
## Purpose
Fix a TypeError in the email service where `nodemailer.createTransporter` was being called instead of the correct method name `nodemailer.createTransport`. The user encountered a runtime error indicating that `createTransporter` is not a function, preventing the email service from initializing properly.

## Code changes
- Updated method name from `nodemailer.createTransporter()` to `nodemailer.createTransport()` in two locations within `backend/services/emailService.js`
- Fixed the production SMTP configuration initialization
- Fixed the test account transporter creation for development/testing environments

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ac3eb84beffe42c59ec5f464719a4b57/aura-space)

👀 [Preview Link](https://ac3eb84beffe42c59ec5f464719a4b57-aura-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ac3eb84beffe42c59ec5f464719a4b57</projectId>-->
<!--<branchName>aura-space</branchName>-->