### PR TITLE
Fix password reset backend URL and error handling

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -4,9 +4,11 @@ export async function POST(request: NextRequest) {
   try {
     const { email } = await request.json()
 
-    // Forward request to backend
-    const backendUrl = process.env.BACKEND_URL || "https://sk-connect-backend-production.up.railway.app"
-    
+    // Forward request to backend - use the correct Railway URL
+    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL ||
+                      process.env.BACKEND_URL ||
+                      "https://sk-connect-backend-production-543c.up.railway.app"
+
     const response = await fetch(`${backendUrl}/api/auth/forgot-password`, {
       method: "POST",
       headers: {
@@ -15,9 +17,27 @@ export async function POST(request: NextRequest) {
       body: JSON.stringify({ email }),
     })
 
-    const data = await response.json()
+    // Check if response is ok before trying to parse JSON
+    if (!response.ok) {
+      // Try to get error message, but handle cases where response isn't JSON
+      let errorMessage = "Failed to send reset email"
+      try {
+        const errorData = await response.json()
+        errorMessage = errorData.message || errorMessage
+      } catch {
+        // If JSON parsing fails, use status text
+        errorMessage = response.statusText || errorMessage
+      }
 
+      return NextResponse.json(
+        { message: errorMessage },
+        { status: response.status }
+      )
+    }
+
+    const data = await response.json()
     return NextResponse.json(data, { status: response.status })
+
   } catch (error) {
     console.error("Forgot password API error:", error)
     return NextResponse.json(

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -5,7 +5,9 @@ export async function POST(request: NextRequest) {
     const { token, password } = await request.json()
 
     // Forward request to backend
-    const backendUrl = process.env.BACKEND_URL || "https://sk-connect-backend-production.up.railway.app"
+    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL ||
+                      process.env.BACKEND_URL ||
+                      "https://sk-connect-backend-production-543c.up.railway.app"
     
     const response = await fetch(`${backendUrl}/api/auth/reset-password`, {
       method: "POST",

--- a/app/api/auth/verify-reset-token/[token]/route.ts
+++ b/app/api/auth/verify-reset-token/[token]/route.ts
@@ -8,7 +8,9 @@ export async function GET(
     const { token } = params
 
     // Forward request to backend
-    const backendUrl = process.env.BACKEND_URL || "https://sk-connect-backend-production.up.railway.app"
+    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL ||
+                      process.env.BACKEND_URL ||
+                      "https://sk-connect-backend-production-543c.up.railway.app"
     
     const response = await fetch(`${backendUrl}/api/auth/verify-reset-token/${token}`, {
       method: "GET",


### PR DESCRIPTION
## Purpose
The user was experiencing issues with password reset functionality where clicking reset password links resulted in DNS errors, 404 pages, and access permission issues. The goal was to fix the backend URL configuration and improve error handling to ensure password reset links work correctly with the newly deployed backend.

## Code changes
- **Updated backend URL**: Changed from `sk-connect-backend-production.up.railway.app` to `sk-connect-backend-production-543c.up.railway.app` across all password reset API routes
- **Enhanced URL resolution**: Added fallback chain using `NEXT_PUBLIC_BACKEND_URL`, `BACKEND_URL`, then the hardcoded Railway URL
- **Improved error handling**: Added proper response validation and JSON parsing error handling in the forgot-password route to prevent crashes when backend returns non-JSON responses
- **Applied changes to**: `forgot-password/route.ts`, `reset-password/route.ts`, and `verify-reset-token/[token]/route.ts`

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ac3eb84beffe42c59ec5f464719a4b57/spark-haven)

👀 [Preview Link](https://ac3eb84beffe42c59ec5f464719a4b57-spark-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ac3eb84beffe42c59ec5f464719a4b57</projectId>-->
<!--<branchName>spark-haven</branchName>-->